### PR TITLE
feat: now using the preferred testing.b.Loop instead of testing.b.N for benchmarks.

### DIFF
--- a/docs/01-common-patterns/src/batching-ops_test.go
+++ b/docs/01-common-patterns/src/batching-ops_test.go
@@ -10,7 +10,6 @@ import (
     "testing"
 )
 
-var sink string
 var lines = make([]string, 10000)
 
 func init() {
@@ -22,23 +21,23 @@ func init() {
 // --- 1. No I/O ---
 
 func BenchmarkUnbatchedProcessing(b *testing.B) {
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         for _, line := range lines {
-            sink = strings.ToUpper(line)
+            strings.ToUpper(line)
         }
     }
 }
 
 func BenchmarkBatchedProcessing(b *testing.B) {
     batchSize := 100
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         for i := 0; i < len(lines); i += batchSize {
             end := i + batchSize
             if end > len(lines) {
                 end = len(lines)
             }
             batch := strings.Join(lines[i:end], "|")
-            sink = strings.ToUpper(batch)
+            strings.ToUpper(batch)
         }
     }
 }
@@ -46,7 +45,7 @@ func BenchmarkBatchedProcessing(b *testing.B) {
 // --- 2. With I/O ---
 
 func BenchmarkUnbatchedIO(b *testing.B) {
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         f, err := os.CreateTemp("", "unbatched")
         if err != nil {
             b.Fatal(err)
@@ -61,7 +60,7 @@ func BenchmarkUnbatchedIO(b *testing.B) {
 
 func BenchmarkBatchedIO(b *testing.B) {
     batchSize := 100
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         f, err := os.CreateTemp("", "batched")
         if err != nil {
             b.Fatal(err)
@@ -87,23 +86,23 @@ func hash(s string) string {
 }
 
 func BenchmarkUnbatchedCrypto(b *testing.B) {
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         for _, line := range lines {
-            sink = hash(line)
+            hash(line)
         }
     }
 }
 
 func BenchmarkBatchedCrypto(b *testing.B) {
     batchSize := 100
-    for n := 0; n < b.N; n++ {
+    for b.Loop() {
         for i := 0; i < len(lines); i += batchSize {
             end := i + batchSize
             if end > len(lines) {
                 end = len(lines)
             }
             joined := strings.Join(lines[i:end], "")
-            sink = hash(joined)
+            hash(joined)
         }
     }
 }

--- a/docs/01-common-patterns/src/buffered-io_test.go
+++ b/docs/01-common-patterns/src/buffered-io_test.go
@@ -44,7 +44,7 @@ func writeBuffered(w io.Writer, count int) {
 }
 
 func BenchmarkWriteNotBuffered(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		f, _ := os.CreateTemp("", "nobuf")
 		writeNotBuffered(f, N)
 		f.Close()
@@ -53,7 +53,7 @@ func BenchmarkWriteNotBuffered(b *testing.B) {
 }
 
 func BenchmarkWriteBuffered(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		f, _ := os.CreateTemp("", "buf")
 		writeBuffered(f, N)
 		f.Close()

--- a/docs/01-common-patterns/src/fields-alignment_test.go
+++ b/docs/01-common-patterns/src/fields-alignment_test.go
@@ -19,25 +19,21 @@ type WellAligned struct {
 }
 // types-simple-end
 
-var result int64
-
 // simple-start
 func BenchmarkPoorlyAligned(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         var items = make([]PoorlyAligned, 10_000_000)
         for j := range items {
             items[j].count = int64(j)
-            result += items[j].count
         }
     }
 }
 
 func BenchmarkWellAligned(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         var items = make([]WellAligned, 10_000_000)
         for j := range items {
             items[j].count = int64(j)
-            result += items[j].count
         }
     }
 }
@@ -63,8 +59,7 @@ func BenchmarkFalseSharing(b *testing.B) {
     var c SharedCounterBad  // (1)
     var wg sync.WaitGroup
 
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         wg.Add(2)
         go func() {
             for i := 0; i < 1_000_000; i++ {
@@ -87,8 +82,7 @@ func BenchmarkNoFalseSharing(b *testing.B) {
     var c SharedCounterGood
     var wg sync.WaitGroup
 
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         wg.Add(2)
         go func() {
             for i := 0; i < 1_000_000; i++ {

--- a/docs/01-common-patterns/src/interface-boxing_test.go
+++ b/docs/01-common-patterns/src/interface-boxing_test.go
@@ -18,49 +18,45 @@ func (LargeJob) Work() {}
 // interface-end
 
 // bench-slice-start
-var sink []Worker
-
 func BenchmarkBoxedLargeSlice(b *testing.B) {
     jobs := make([]Worker, 0, 1000)
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         jobs = jobs[:0]
         for j := 0; j < 1000; j++ {
             var job LargeJob
             jobs = append(jobs, job)
         }
-        sink = jobs
     }
 }
 
 func BenchmarkPointerLargeSlice(b *testing.B) {
     jobs := make([]Worker, 0, 1000)
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         jobs := jobs[:0]
         for j := 0; j < 1000; j++ {
             job := &LargeJob{}
             jobs = append(jobs, job)
         }
-        sink = jobs
     }
 }
 // bench-slice-end
 
 // bench-call-start
-var sinkOne Worker
+var sink Worker
 
 func call(w Worker) {
-    sinkOne = w
+    sink = w
 }
 
 func BenchmarkCallWithValue(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         var j LargeJob
         call(j)
     }
 }
 
 func BenchmarkCallWithPointer(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         j := &LargeJob{}
         call(j)
     }

--- a/docs/01-common-patterns/src/mem-prealloc_test.go
+++ b/docs/01-common-patterns/src/mem-prealloc_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func BenchmarkAppendNoPrealloc(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         var s []int
         for j := 0; j < 10000; j++ {
             s = append(s, j)
@@ -14,7 +14,7 @@ func BenchmarkAppendNoPrealloc(b *testing.B) {
 }
 
 func BenchmarkAppendWithPrealloc(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         s := make([]int, 0, 10000)
         for j := 0; j < 10000; j++ {
             s = append(s, j)

--- a/docs/01-common-patterns/src/object-pooling_test.go
+++ b/docs/01-common-patterns/src/object-pooling_test.go
@@ -10,14 +10,11 @@ type Data struct {
 	Values [1024]int
 }
 
-// globalSink prevents compiler optimizations that could remove memory allocations.
-var globalSink *Data
-
 // BenchmarkWithoutPooling measures the performance of direct heap allocations.
 func BenchmarkWithoutPooling(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		globalSink = &Data{}      // Allocating a new object each time
-		globalSink.Values[0] = 42 // Simulating some memory activity
+	for b.Loop() {
+    data := &Data{}      // Allocating a new object each time
+		data.Values[0] = 42 // Simulating some memory activity
 	}
 }
 
@@ -30,10 +27,9 @@ var dataPool = sync.Pool{
 
 // BenchmarkWithPooling measures the performance of using sync.Pool to reuse objects.
 func BenchmarkWithPooling(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		obj := dataPool.Get().(*Data) // Retrieve from pool
 		obj.Values[0] = 42            // Simulate memory usage
 		dataPool.Put(obj)             // Return object to pool for reuse
-		globalSink = obj              // Prevents compiler optimizations from removing pooling logic
 	}
 }

--- a/docs/01-common-patterns/src/stack-alloc_test.go
+++ b/docs/01-common-patterns/src/stack-alloc_test.go
@@ -16,13 +16,13 @@ func HeapAlloc() *Data {
 }
 
 func BenchmarkStackAlloc(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         _ = StackAlloc()
     }
 }
 
 func BenchmarkHeapAlloc(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         _ = HeapAlloc()
     }
 }
@@ -37,7 +37,7 @@ func HeapAllocEscape() {
 }
 
 func BenchmarkHeapAllocEscape(b *testing.B) {
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         HeapAllocEscape()
     }
 }

--- a/docs/01-common-patterns/src/worker-pool_test.go
+++ b/docs/01-common-patterns/src/worker-pool_test.go
@@ -21,7 +21,7 @@ func doWork(n int) [32]byte {
 }
 
 func BenchmarkUnboundedGoroutines(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var wg sync.WaitGroup
 		wg.Add(numJobs)
 
@@ -43,7 +43,7 @@ func worker(jobs <-chan int, wg *sync.WaitGroup) {
 }
 
 func BenchmarkWorkerPool(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var wg sync.WaitGroup
 		wg.Add(numJobs)
 

--- a/docs/01-common-patterns/src/zero-copy_test.go
+++ b/docs/01-common-patterns/src/zero-copy_test.go
@@ -10,22 +10,18 @@ import (
 )
 
 // bench-start
-var sink []byte
-
 func BenchmarkCopy(b *testing.B) {
     data := make([]byte, 64*1024)
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         buf := make([]byte, len(data))
         copy(buf, data)
-        sink = buf
     }
 }
 
 func BenchmarkSlice(b *testing.B) {
     data := make([]byte, 64*1024)
-    for i := 0; i < b.N; i++ {
-        s := data[:]
-        sink = s
+    for b.Loop() {
+        _ = data[:]
     }
 }
 // bench-end
@@ -39,13 +35,11 @@ func BenchmarkReadWithCopy(b *testing.B) {
     defer f.Close()
 
     buf := make([]byte, 4*1024*1024) // 4MB buffer
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         _, err := f.ReadAt(buf, 0)
         if err != nil && err != io.EOF {
             b.Fatal(err)
         }
-        sink = buf
     }
 }
 
@@ -57,13 +51,11 @@ func BenchmarkReadWithMmap(b *testing.B) {
     defer r.Close()
 
     buf := make([]byte, r.Len())
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for b.Loop() {
         _, err := r.ReadAt(buf, 0)
         if err != nil && err != io.EOF {
             b.Fatal(err)
         }
-        sink = buf
     }
 }
 // bench-io-end


### PR DESCRIPTION
PR linked to the [following issue](https://github.com/astavonin/go-optimization-guide/issues/9).