### PR TITLE
fix: add lock to flushNow method to prevent race conditions

### DIFF
--- a/docs/01-common-patterns/batching-ops.md
+++ b/docs/01-common-patterns/batching-ops.md
@@ -63,6 +63,8 @@ func (b *Batcher[T]) Add(item T) {
 }
 
 func (b *Batcher[T]) flushNow() {
+    b.mu.Lock()
+    defer b.mu.Unlock()
     if len(b.buffer) == 0 {
         return
     }


### PR DESCRIPTION
PR linked to this issue https://github.com/astavonin/go-optimization-guide/issues/12.