### PR TITLE
style: fix unintended line on object-pooling_test.go

### DIFF
--- a/docs/01-common-patterns/src/object-pooling_test.go
+++ b/docs/01-common-patterns/src/object-pooling_test.go
@@ -13,8 +13,8 @@ type Data struct {
 // BenchmarkWithoutPooling measures the performance of direct heap allocations.
 func BenchmarkWithoutPooling(b *testing.B) {
 	for b.Loop() {
-    data := &Data{}      // Allocating a new object each time
-		data.Values[0] = 42 // Simulating some memory activity
+		data := &Data{}      // Allocating a new object each time
+		data.Values[0] = 42  // Simulating some memory activity
 	}
 }
 


### PR DESCRIPTION
This fixes a line with the wrong indentation level in the benchmark code used for the ["Object Pooling"](https://goperf.dev/01-common-patterns/object-pooling/) page.