### PR TITLE
fix: net-app.go slow response ms print

### DIFF
--- a/docs/02-networking/src/net-app.go
+++ b/docs/02-networking/src/net-app.go
@@ -41,7 +41,7 @@ func slowHandler(w http.ResponseWriter, r *http.Request) {
 	delayRange := int((*slowMax - *slowMin) / time.Millisecond)
 	delay := time.Duration(randRange(1, delayRange)) * time.Millisecond
 	time.Sleep(delay)
-	fmt.Fprintf(w, "slow response with delay %d ms\n", delay)
+	fmt.Fprintf(w, "slow response with delay %d ms\n", delay.Milliseconds())
 }
 
 // heavy-start


### PR DESCRIPTION
Duration is in ns, not ms, so currently printing as
```
$ curl localhost:6060/slow
slow response with delay 103000000 ms
```

This fixes it to print:
```
$ curl localhost:6060/slow
slow response with delay 129 ms
```