### PR TITLE
chore: fixes typos in benchmark and load testing page

### DIFF
--- a/docs/02-networking/bench-and-load.md
+++ b/docs/02-networking/bench-and-load.md
@@ -362,11 +362,11 @@ For example, if profiling shows excessive time spent in TLS handshake routines, 
 
 **Why it matters:** CPU bottlenecks cap your ability to scale. Fixing them is often the difference between a system that handles 5K clients and one that handles 50K.
 
-### Practicle example of Profiling Networked Go Applications with `pprof`
+### Practical example of Profiling Networked Go Applications with `pprof`
 
 To illustrate these concepts practically, our demo application integrates profiling and benchmarking tools and provides comprehensive profiling and load testing scenarios. The demo covers identifying performance bottlenecks, analyzing flame graphs, and benchmarking under various simulated network conditions.
 
-Due to its significant size, [Practicle example of Profiling Networked Go Applications with `prof`](gc-endpoint-profiling.md) is a separate article.
+Due to its significant size, [Practical example of Profiling Networked Go Applications with `prof`](gc-endpoint-profiling.md) is a separate article.
 
 ## Benchmarking as a Feedback Loop
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
     - 02-networking/index.md
     - Benchmarking First:
       - Benchmarking and Load Testing for Networked Go Apps: 02-networking/bench-and-load.md
-      - Practicle example of Profiling Networked Go Applications with pprof: 02-networking/gc-endpoint-profiling.md
+      - Practical example of Profiling Networked Go Applications with pprof: 02-networking/gc-endpoint-profiling.md
     - Foundations and Core Concepts:
       - How Go Handles Networking: 02-networking/networking-internals.md
       - Efficient Use of net/http, net.Conn, and UDP: 02-networking/efficient-net-use.md


### PR DESCRIPTION
This pull request corrects a spelling error in the documentation and navigation files by changing "Practicle" to "Practical" in references to the profiling example. This improves clarity and professionalism in the documentation.

Documentation corrections:

* Fixed the spelling of "Practical" in section headings and article references in `02-networking/bench-and-load.md` and the navigation in `mkdocs.yml`.